### PR TITLE
CodeMirror 6: Fix header token position and image fade-in

### DIFF
--- a/src/style/focus.css
+++ b/src/style/focus.css
@@ -1,12 +1,17 @@
-div.CodeMirror .CodeMirror-line, div.CodeMirror img {
+div.CodeMirror .CodeMirror-line,
+div.CodeMirror img,
+div.cm-editor .cm-line {
   opacity: 0.4;
   color: var(--joplin-color) !important;
 	transition: opacity 0.2s;
 }
 
 div.CodeMirror .CodeMirror-activeline .CodeMirror-line,
+div.CodeMirror .CodeMirror-activeline img,
+
 div.CodeMirror .CodeMirror-activeline.cm-line,
-div.CodeMirror .CodeMirror-activeline img {
+div.cm-editor .CodeMirror-activeline + .rich-markdown-resource.cm-line > img,
+div.cm-editor .CodeMirror-activeline + .rich-markdown-resource.cm-line {
   opacity: 1.0;
 	transition: opacity 0.4s;
 }

--- a/src/style/focus.css
+++ b/src/style/focus.css
@@ -1,6 +1,6 @@
 div.CodeMirror .CodeMirror-line,
-div.CodeMirror img,
-div.cm-editor .cm-line {
+div.cm-editor .cm-line,
+div.CodeMirror img {
   opacity: 0.4;
   color: var(--joplin-color) !important;
 	transition: opacity 0.2s;
@@ -8,7 +8,6 @@ div.cm-editor .cm-line {
 
 div.CodeMirror .CodeMirror-activeline .CodeMirror-line,
 div.CodeMirror .CodeMirror-activeline img,
-
 div.CodeMirror .CodeMirror-activeline.cm-line,
 div.cm-editor .CodeMirror-activeline + .rich-markdown-resource.cm-line > img,
 div.cm-editor .CodeMirror-activeline + .rich-markdown-resource.cm-line {

--- a/src/style/stylish.css
+++ b/src/style/stylish.css
@@ -13,7 +13,8 @@ div.CodeMirror span.cm-hr {
 /* END Horizontal Rule*/
 
 /* Blockquotes */
-pre.cm-rm-blockquote.CodeMirror-line {
+pre.cm-rm-blockquote.CodeMirror-line,
+pre.cm-rm-blockquote.cm-line {
 	border-left: 4px solid var(--joplin-code-border-color);
 	opacity: 0.7;
 }
@@ -61,35 +62,42 @@ div.CodeMirror .cm-jn-code-block .cm-katex-marker-close {
 /* END Fade tokens*/
 
 /* Headers */
-div.CodeMirror .cm-header.cm-rm-header-token:not(.cm-whitespace-a, .cm-whitespace-b) {
+div.CodeMirror .cm-header.cm-rm-header-token:not(.cm-whitespace-a, .cm-whitespace-b),
+div.cm-editor .cm-header > .cm-rm-header-token {
 	font-family: monospace;
 	font-size: 0.9em;
 	/* Add some spacing for breathing room */
 	margin-right: 0.3ex;
 }
-div.CodeMirror .cm-rm-header-token.cm-header-1:not(.cm-whitespace-a, .cm-whitespace-b) {
+div.CodeMirror .cm-rm-header-token.cm-header-1:not(.cm-whitespace-a, .cm-whitespace-b),
+div.cm-editor .cm-header.cm-h1 > .cm-rm-header-token {
 	/* 1ex is the height of a lowercase x, it's an approximation for width */
 	/* We need 2ex to account for the space character */
 	margin-left: -2ex;
 }
 
-div.CodeMirror .cm-rm-header-token.cm-header-2:not(.cm-whitespace-a, .cm-whitespace-b) {
+div.CodeMirror .cm-rm-header-token.cm-header-2:not(.cm-whitespace-a, .cm-whitespace-b),
+div.cm-editor .cm-header.cm-h2 > .cm-rm-header-token {
 	margin-left: -3ex;
 }
 
-div.CodeMirror .cm-rm-header-token.cm-header-3:not(.cm-whitespace-a, .cm-whitespace-b) {
+div.CodeMirror .cm-rm-header-token.cm-header-3:not(.cm-whitespace-a, .cm-whitespace-b),
+div.cm-editor .cm-header.cm-h3 > .cm-rm-header-token {
 	margin-left: -4ex;
 }
 
-div.CodeMirror .cm-rm-header-token.cm-header-4:not(.cm-whitespace-a, .cm-whitespace-b) {
+div.CodeMirror .cm-rm-header-token.cm-header-4:not(.cm-whitespace-a, .cm-whitespace-b),
+div.cm-editor .cm-header.cm-h4 > .cm-rm-header-token {
 	margin-left: -5ex;
 }
 
-div.CodeMirror .cm-rm-header-token.cm-header-5:not(.cm-whitespace-a, .cm-whitespace-b) {
+div.CodeMirror .cm-rm-header-token.cm-header-5:not(.cm-whitespace-a, .cm-whitespace-b),
+div.cm-editor .cm-header.cm-h5 > .cm-rm-header-token {
 	margin-left: -6ex;
 }
 
-div.CodeMirror .cm-rm-header-token.cm-header-6:not(.cm-whitespace-a, .cm-whitespace-b) {
+div.CodeMirror .cm-rm-header-token.cm-header-6:not(.cm-whitespace-a, .cm-whitespace-b),
+div.cm-editor .cm-header.cm-h6 > .cm-rm-header-token {
 	margin-left: -7ex;
 }
 /* END Headers */


### PR DESCRIPTION
# Summary

This is a follow-up pull request to #58. It fixes issues related to the stylish theme and focus mode.

More specifically, it does the following:
- Corrects the position of `#` characters in headings in the `stylish` theme in CodeMirror 6.
- Corrects the opacity of `img` tags just below the active line.
- Removes reliance on `.CodeMirror-line` selectors (allowing them to be removed from the [upstream pull request](https://github.com/laurent22/joplin/pull/9935))
    - The upstream pull request had previously added the `CodeMirror-line` class to each visible line. 

# Screenshots

**CodeMirror 5**:
![screenshot: CodeMirror 5 editor with rich markdown](https://github.com/CalebJohn/joplin-rich-markdown/assets/46334387/5e14dfbb-7820-4f28-8124-9db715f9cb88)

**CodeMirror 6**:
![screenshot: CodeMirror 6 editor with rich markdown](https://github.com/CalebJohn/joplin-rich-markdown/assets/46334387/f87f2592-8569-44e9-bc32-94aca01e6c48)
