### PR TITLE
User-defined regex overlays

### DIFF
--- a/src/overlay.ts
+++ b/src/overlay.ts
@@ -41,7 +41,7 @@ function exec(query: RegExp, stream: any) {
 	return query.exec(stream.string);
 }
 
-function regexOverlay(name: string, regex: RegExp, requiredSettings: string[]) {
+export function regexOverlay(name: string, regex: RegExp, requiredSettings: string[]) {
 	// Hack to allow the backtick regexes in code blocks
 	const allowedInCodeblock = name.indexOf("tick") > 0;
 	return {
@@ -80,7 +80,7 @@ function regexOverlay(name: string, regex: RegExp, requiredSettings: string[]) {
 	};
 }
 
-const overlays = [
+export const overlays = [
 	regexOverlay('rm-checkbox', checkbox_regex, []),
 	regexOverlay('rm-checkbox-check', checkbox_inner_regex, ['extraCSS']),
 	regexOverlay('rm-link', link_regex, []),

--- a/src/richMarkdown.ts
+++ b/src/richMarkdown.ts
@@ -45,6 +45,16 @@ module.exports = {
 					this.on('mousedown', on_mousedown);
 					this.on('renderLine', on_renderLine);
 
+					try {
+						JSON.parse(settings.regexOverlays).forEach((overlay: any) => {
+							Overlay.overlays.push(
+								Overlay.regexOverlay(overlay.name, new RegExp(overlay.regex, 'g'), ['extraCSS'])
+							);
+						});
+					} catch (e) {
+						console.error('Error parsing regexOverlays', e);
+					}
+
 					Overlay.add(this);
 					IndentHandlers.calculateSpaceWidth(this);
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -20,6 +20,7 @@ export interface RichMarkdownSettings {
 	theme: string;
 	extraFancy: string;
 	cssPath: string;
+	regexOverlays: string;
 }
 
 export async function getAllSettings(): Promise<RichMarkdownSettings> {
@@ -42,6 +43,7 @@ export async function getAllSettings(): Promise<RichMarkdownSettings> {
 		theme: await joplin.settings.value('theme'),
 		extraFancy: await joplin.settings.value('extraFancy'),
 		cssPath: await joplin.plugins.installationDir(),
+		regexOverlays: await joplin.settings.value('regexOverlays'),
 	}
 }
 
@@ -164,6 +166,15 @@ export async function registerAllSettings() {
 			public: true,
 			label: 'Hide Markdown Elements',
 			description: 'Fades the markdown characters on other lines',
+		},
+		'regexOverlays': {
+			value: '',
+			type: SettingItemType.String,
+			section: 'settings.calebjohn.richmarkdown',
+			public: true,
+			advanced: true,
+			label: 'Custom classes JSON',
+			description: 'Add custom classes in the format of [{"name": "className", "regex": string}] to create custom overlays referenced as "cm-className".',
 		},
 	});
 	registerToggle('inlineImages',


### PR DESCRIPTION
The goal is to enable users to easily create their own CSS classes by providing a regex and a name for the class.
In practice, this is done by typing a list of JSONs in the advanced settings section.
For example, I used this to highlight inline tags by defining the following JSON in the settings:

<img width="335" alt="image" src="https://github.com/CalebJohn/joplin-rich-markdown/assets/17462125/b2a2b9ff-2445-4b12-8b16-1b0b8b3f3196">

I'm not sure about the exact wording / name for the feature.

(I initially intended to create a PR for inline tag highlighting, but thought that this is a more flexible approach.)