### PR TITLE
feat: open Excalidraw plugin dialog on click

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,11 @@ joplin.plugins.register({
 				if (!url.startsWith(':/') && !url.match(/^(?:[a-zA-Z0-9\+\.\-])+:/)) {
 					url = 'http://' + url;
 				}
-				await joplin.commands.execute('openItem', url);
+        if (url.startsWith('excalidraw://')) {
+          await joplin.commands.execute('app.excalidraw.openItem', url);
+        } else {
+          await joplin.commands.execute('openItem', url);
+        }
 			},
 		});
 


### PR DESCRIPTION
This change adds support for opening Excalidraw plugin items when a URL with the
'excalidraw://' scheme is clicked in richMarkdown. 

Behavior:
- URLs starting with 'excalidraw://' execute the 'app.excalidraw.openItem' command.
- All other URLs use the default 'openItem' command.

This allows richMarkdown to seamlessly integrate with the Excalidraw plugin,
making it easier for users to open Excalidraw items directly from markdown links.
