### PR TITLE
Fix issues related to reference style link regex

### DIFF
--- a/src/clickHandlers.ts
+++ b/src/clickHandlers.ts
@@ -124,10 +124,15 @@ function getLinkAt(cm: any, coord: any) {
 		if (!reference_match) return;
 
 		const reference = reference_match[1] || reference_match[2];
+		const trimmedReference = reference.trim();
 
-		if (reference.trim() === '' || reference.toLowerCase() === 'x') return; // This is a checkbox
+		if (trimmedReference === '' || trimmedReference.toLowerCase() === 'x') return; // This is a checkbox
 
-		const link_definition_regex = new RegExp(`\\[${reference}\\]:\\s([^\\n]+)`, 'g');
+		// Skip Joplin directives or wiki style links such as [[toc]] that surface nested brackets
+		if (trimmedReference.includes('[') || trimmedReference.includes(']')) return;
+
+		const escapedReference = trimmedReference.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+		const link_definition_regex = new RegExp(`\\[${escapedReference}\\]:\\s([^\\n]+)`, 'g');
 
 		for (let i = 0; i < cm.lineCount(); i++) {
 			// a link reference definition can only be preceded by up to 3
@@ -143,7 +148,7 @@ function getLinkAt(cm: any, coord: any) {
 
 		// No match found, just exit
 		if (url === '') {
-			alert(`No link defintion for [${reference}]. Press Esc to dismiss.`);
+			alert(`No link defintion for [${trimmedReference}]. Press Esc to dismiss.`);
 			return;
 		}
 	}
@@ -244,4 +249,3 @@ export function toggleCheckbox(cm: any, coord: any, replacement: string) {
 
 	return true;
 }
-


### PR DESCRIPTION
Fixes most of the issues from #87 

**NOTE:** This does **not** fix the scenario where a no link definition error appears when right clicking something that's formatted like a reference style link inside a code block (the `[Text.Encoding]` scenario from issue 87). 

These changes only address the other scenarios (the right click menu not appearing at all when right clicking selected text in the code block, and when right clicking in a note that contains double-bracketed text such as `[[toc]]`. The change also prevents a no link definition error from appearing when right clicking on [[toc]].


## Changes

Guarded reference-link handling from nested brackets so directives like [[toc]] bail early instead of triggering an alert or regex build

Escaped special characters before constructing the reference-definition regex to stop invalid pattern errors when right-clicking wiki-style tokens

## Testing performed:

1\. Ran npm test and verified that all tests still pass

2\. Built plugin and tested the scenarios from issue #87 and they now work as expected (no console errors, right click menu appears, and right clicking [[toc]] doesn't display a no link definition message)

**NOTE:** As mentioned above, you can still see a no link definition message when right clicking bracketed text inside code.

4\. Tested with valid reference style links, e.g:

```
Here is a [google] and another [google] for good measure.

[google]: https://www.google.com "Google Search Engine"
```
Verified that right clicking on [google] still shows the "Open Link" option, and that selecting open link opens the referenced https://www.google.com in browser. Verified that "Copy link to clipboard" copies the referenced URL as expected.

**NOTE:** I tested ctrl + clicking a reference style link with the option to follow links with ctrl enabled, and this throws a console error, but this does **not** appear to be related to rich markdown (same error occurs when the option to follow links with ctrl is disabled, and even when rich markdown plugin is disabled). This appears to be an issue with the new ctrl + click link following that was added upstream in joplin 3.4.x (so I will report that upstream)

```
main-html.bundle.js.map:1 Uncaught (in promise) TypeError: Invalid URL
    at new URL (node:internal/url:818:25)
    at sY.openExternal (C:\Program Files\Joplin\resources\app.asar\main.bundle.js:2875:4191)
    at C:\Program Files\Joplin\resources\app.asar\node_modules\@electron\remote\dist\src\main\server.js:480:71
    at IpcMainImpl.<anonymous> (C:\Program Files\Joplin\resources\app.asar\node_modules\@electron\remote\dist\src\main\server.js:323:27)
    at IpcMainImpl.emit (node:events:518:28)
    at IpcMainImpl.emit (node:domain:489:12)
    at WebContents.<anonymous> (node:electron/js2c/browser_init:2:89937)
    at WebContents.emit (node:events:518:28)
    at WebContents.emit (node:domain:489:12)
```

5\. Tested scenario with invalid reference:

```
Here is a [google] and another [google] for good measure.

[invalid]: https://www.google.com "Google Search Engine"
```

Verified that right clicking `[google]` shows expected error that there is no link definition for `[google]`

6\. Tested other context menu functions:

- Open link (with bare http(s) URL, markdown formatted URL, joplin image resource link)
- Copy Image
- Copy Path to clipboard
- Reveal file in folder